### PR TITLE
Drop unused "executables" directive from gemspec

### DIFF
--- a/rack-token_auth.gemspec
+++ b/rack-token_auth.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/iain/rack-token_auth"
 
   gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 


### PR DESCRIPTION
This gem exposes no executable.